### PR TITLE
Fixed #97

### DIFF
--- a/metadata/datasets.yaml
+++ b/metadata/datasets.yaml
@@ -436,7 +436,7 @@
     short_name: switchTask
     key: 1qkGFqZLwuuO5ELKiFg4E5EGX5O6xTfJC_hxyZXJr2zI
     filename: switchTask
-    citation: "Tsui et al. (2019) »
+    citation: "Tsui et al. (2019)"
     internal_citation: ""
     link: "https://drive.google.com/drive/folders/15-R_Nvm5sU2rakIH4s4U7ANue_bzm4Qu"
     full_citation: "Tsui, A. S. M., Byers-Heinlein, K., & Fennell, C. T. (2019, February 7). Associative Word Learning in Infancy: A Meta-Analysis of the Switch Task. Developmental Psychology. Advance online publication."

--- a/shinyapps/visualization/server.R
+++ b/shinyapps/visualization/server.R
@@ -393,6 +393,7 @@ shinyServer(function(input, output, session) {
 
     ggplotly(plt, tooltip = c("text")) %>%
       layout(showlegend = FALSE)
+
   }
 
   forest_summary <- function() {
@@ -432,8 +433,10 @@ shinyServer(function(input, output, session) {
     forest()
   })
 
+  ## This is the rendering function for the meta-analytic model summery of the effect size
   output$forest_summary <- renderPlot(forest_summary(), height = 200)
 
+  ## This is the output function for the model summary
   output$forest_summary_text <- renderPrint({
     summary(model())
   })

--- a/shinyapps/visualization/ui.R
+++ b/shinyapps/visualization/ui.R
@@ -136,8 +136,9 @@ shinyUI(
                     p(strong("Forest plot"),
                       "of effect sizes and meta-analysis model estimates"))
                   ),
+                fluidRow(width=10,
                 column(
-                  width = 4,
+                  width = 10,
                   selectInput("forest_sort", label = "Sort order",
                               choices = c("weight (1/variance)" = "variances",
                                           "effect size" = "effects",
@@ -147,7 +148,7 @@ shinyUI(
                   bsPopover("forest_sort", title = NULL,
                             content = HTML("<small>Method to sort results</small>"),
                             placement = "right")
-                ),
+                )),
                 plotlyOutput("forest"),
                 # ggplotly hack - renderPlotly does not take height param; must alter in UI
                 tags$script('


### PR DESCRIPTION
Created a new fluid row to address the box covering up part of the forest plot. Also fixed a small bug that threw an error from the metadata yaml file. See #97 for a screenshot of the problem, this is the new version as seen below. There is room to add another menu if the team would like one added, maybe to change the colors for people who are color blind or something. 

![image](https://user-images.githubusercontent.com/2274317/55062301-e6aa0600-5032-11e9-8f5c-a33baa730dc4.png)
